### PR TITLE
Quick update if Mirror/pull/125 accepted

### DIFF
--- a/IgnoranceTransport/IgnoranceTransport.cs
+++ b/IgnoranceTransport/IgnoranceTransport.cs
@@ -73,7 +73,7 @@ namespace Mirror
         /// Please see https://github.com/nxrighthere/ENet-CSharp/issues/33 for more information.
         /// </summary>
         /// <returns>A integer with the maximum packet size.</returns>
-        public int GetMaxPacketSize()
+        public int GetMaxPacketSize(int channelId)
         {
             return (int)Library.maxPacketSize;  // 33,554,432 bytes.
         }


### PR DESCRIPTION
Only merge this if https://github.com/vis2k/Mirror/pull/125 is accepted.

It effectively changes nothing with your transport but will stop it erroring :) As your transport doesn't have different max packet sizes for different channels you can silently ignore the channel