### PR TITLE
Update IgnoranceTransport.cs

### DIFF
--- a/IgnoranceTransport/IgnoranceTransport.cs
+++ b/IgnoranceTransport/IgnoranceTransport.cs
@@ -699,7 +699,7 @@ namespace Mirror
         }
 
         // Mirror master update loops.
-        public void Update()
+        public void LateUpdate()
         {
             while (ProcessClientMessage()) ;
             while (ProcessServerMessage()) ;


### PR DESCRIPTION
Per Transport.cs in Mirror

        // block Update() to force Transports to use LateUpdate to avoid race
        // conditions. messages should be processed after all the game state
        // was processed in Update.
        // -> in other words: use LateUpdate!
        // -> uMMORPG 480 CCU stress test: when bot machine stops, it causes
        //    'Observer not ready for ...' log messages when using Update
        // -> occupying a public Update() function will cause Warnings if a
        //    transport uses Update.