### PR TITLE
BUG: Ignorance delivers messages even when this.enabled == false across scene loads 

### DIFF
--- a/IgnoranceTransport/IgnoranceTransport.cs
+++ b/IgnoranceTransport/IgnoranceTransport.cs
@@ -701,8 +701,8 @@ namespace Mirror
         // Mirror master update loops.
         public void Update()
         {
-            while (ProcessClientMessage()) ;
-            while (ProcessServerMessage()) ;
+            while (enabled && ProcessClientMessage()) ;
+            while (enabled && ProcessServerMessage()) ;
         }
 
         // -- TIMEOUT SETTINGS -- //


### PR DESCRIPTION
See https://github.com/vis2k/Mirror/pull/379 for details.

Found this bug when joining a server using Unity 2018.3
TelepathyTransport delivers the first message which tells the client to change scenes and load the next scene.
However because the LateUpdate has already started, it doesn't check that this.enabled and processes the rest of the message queue during the scene transition.

Debugged and diagnosed with Paul to find this issue.