### PR TITLE
Restore a lost meta file

### DIFF
--- a/Assets/Mirror/Transports.meta
+++ b/Assets/Mirror/Transports.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 62371498316d6084893d12465fff8ff5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Transports.meta file has been deleted with this commit, is not it necessary?
https://github.com/SoftwareGuy/Ignorance/commit/142d55afbe93894626ef5c0b2716503bda4f901c#diff-f8f7faf0e0a9359263ea24dc2626a362
