### PR TITLE
ENet polling in a job

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Ignorance/ChannelType.cs
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/ChannelType.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using ENet;
+
+namespace Mirror.Ignorance
+{
+    [Serializable]
+    public enum ChannelType
+    {
+        Reliable,
+        Unreliable,
+        UnreliableFragmented,
+        UnreliableSequenced,
+    }
+
+    public static class ChannelTypeExtensions
+    {
+        public static PacketFlags ToENetPacketFlag(this ChannelType type)
+        {
+            switch (type)
+            {
+                case ChannelType.Reliable:
+                    return PacketFlags.Reliable;
+                case ChannelType.Unreliable:
+                    return PacketFlags.Unsequenced;
+                case ChannelType.UnreliableFragmented:
+                    return PacketFlags.UnreliableFragment;
+                case ChannelType.UnreliableSequenced:
+                    return PacketFlags.None;
+                default:
+                    return PacketFlags.Unsequenced;
+            }
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/Transport/Ignorance/ChannelType.cs.meta
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/ChannelType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ecda36bbccef2224698a1d6722386549
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceTransportInspector.cs
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceTransportInspector.cs
@@ -16,10 +16,10 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace Mirror
+namespace Mirror.Ignorance
 {
     [CustomEditor(typeof(IgnoranceTransport))]
-    public class IgnoranceTransportInspector : Editor
+    public class IgnoranceTransportInspector : UnityEditor.Editor
     {
         bool showGeneralSettings = true;
         bool showServerSettings = true;

--- a/Assets/Mirror/Runtime/Transport/Ignorance/ServerPumpJob.cs
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/ServerPumpJob.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using ENet;
+using Unity.Collections;
+using Unity.Jobs;
+
+namespace Mirror.Ignorance
+{
+    public struct ServerPumpJob
+        : IJob
+    {
+        private readonly IntPtr _enetHost;
+
+        private NativeArray<ENetEvent> _events;
+        private NativeArray<int> _counterOut;
+        private int _count;
+
+        public ServerPumpJob(IntPtr enetHost, NativeArray<ENetEvent> output, NativeArray<int> count)
+        {
+            _enetHost = enetHost;
+            _events = output;
+            _count = 0;
+            _counterOut = count;
+        }
+
+        public void Execute()
+        {
+            try
+            {
+                //First read events we didn't manage to read last time (possible buffer exhaustion?)
+                CheckEvents();
+
+                //Check if we've filled the buffer, early exit if so
+                if (_count == _events.Length)
+                    return;
+
+                //Pump enet and store the single event from it
+                if (Native.enet_host_service(_enetHost, out var evt, 0) <= 0)
+                    return;
+
+                _events[_count++] = evt;
+
+                //Read the rest of the events
+                CheckEvents();
+            }
+            finally
+            {
+                _counterOut[0] = _count;
+            }
+        }
+
+        private void CheckEvents()
+        {
+            while (Native.enet_host_check_events(_enetHost, out var nativeEvent) > 0 && _count < _events.Length)
+                _events[_count++] = nativeEvent;
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/Transport/Ignorance/ServerPumpJob.cs.meta
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/ServerPumpJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e71b4dee9e483fa4aa4e7ca58113fd10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is just a very hacky example of how to poll ENet in a job, by no means is this an actual pull request which should be merged!

The main event loop:
 - Create and schedule a job
 - _Next frame_ wait for the job (it should already be finished) and then consume the ENet events it received.
 - Schedule another job

Actual processing of the ENet events isn't moved into a background thread, obviously you'd want to move as much of that into a job as possible in practice.

There's some other unrelated stuff, mostly just spring cleaning as I was looking around the codebase. better namespacing, moving ChannelType out to a separate file, `ToENetPacketFlag` extension etc. You can pretty much ignore all that.