### PR TITLE
 IgnoranceThreaded: Ensure channel is set on IncomingPacket on client receive

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceThreaded.cs
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceThreaded.cs
@@ -487,6 +487,7 @@ namespace Mirror
 
                                     IncomingPacket dataPkt = default;
                                     dataPkt.type = MirrorPacketType.ClientGotData;
+                                    dataPkt.channelId = networkEvent.ChannelID;
                                     dataPkt.data = new byte[spLength];  // Grrr!!!
                                     networkEvent.Packet.CopyTo(dataPkt.data);
 


### PR DESCRIPTION
Currently, when a client receives a packet from the server, the channel ID is never set. This PR fixes that by ensuring the channel is set before the packet is forwarded to Mirror.