### PR TITLE
fix: preserve message length

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceThreaded.cs
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceThreaded.cs
@@ -132,7 +132,7 @@ namespace Mirror
                         OnServerDisconnected?.Invoke(pkt.mirrorClientId);
                         break;
                     case QueuePacketType.Server_IncomingData:
-                        OnServerDataReceived?.Invoke(pkt.mirrorClientId, new ArraySegment<byte>(pkt.data), pkt.channelId);
+                        OnServerDataReceived?.Invoke(pkt.mirrorClientId, new ArraySegment<byte>(pkt.data, 0, pkt.length), pkt.channelId);
                         System.Buffers.ArrayPool<byte>.Shared.Return(pkt.data, true);
                         break;
                     default:
@@ -492,6 +492,7 @@ namespace Mirror
                                         byte[] rentedBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(netEvent.Packet.Length);
                                         netEvent.Packet.CopyTo(rentedBuffer);
                                         dataPkt.data = rentedBuffer;
+                                        dataPkt.length = netEvent.Packet.Length;
 
                                         ClientIncomingQueue.Enqueue(dataPkt);
                                     }

--- a/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceThreaded.cs
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceThreaded.cs
@@ -170,7 +170,7 @@ namespace Mirror
                         OnClientDisconnected?.Invoke();
                         break;
                     case QueuePacketType.Client_IncomingData:
-                        OnClientDataReceived?.Invoke(new ArraySegment<byte>(pkt.data), pkt.channelId);
+                        OnClientDataReceived?.Invoke(new ArraySegment<byte>(pkt.data, 0, pkt.length), pkt.channelId);
                         System.Buffers.ArrayPool<byte>.Shared.Return(pkt.data, true);
                         break;
                 }
@@ -740,6 +740,7 @@ namespace Mirror
                                         netEvent.Packet.CopyTo(rentedBuffer);
 
                                         dataPkt.data = rentedBuffer;
+                                        dataPkt.length = netEvent.Packet.Length;
 
                                         ServerIncomingQueue.Enqueue(dataPkt);
 

--- a/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceThreaded.cs
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/IgnoranceThreaded.cs
@@ -913,6 +913,7 @@ namespace Mirror
             public QueuePacketType type;            // What type of packet is this?
             public byte[] data;                     // The packet data payload (later recycled via BufferPool)
             public string ipAddress;                // The IP address of the client that sent us the packet.
+            internal int length;
         }
 
         // Outgoing packet struct


### PR DESCRIPTION
My server was sending:
EF-03-BC-06-B9-6A-6A-48-D2-F8-3D-2B-EA-99-A9-18-65-CF-30-77-D4-3D-F7-15-91-71-FD-52-65-BC-5E-7B-A7-4A-33-5E-58-2C-72-16-63-59-E4-99-61-A4-37-0E-75-5C-04-A0-72-65-D5-EC-EB-31-65-9D-01-95-5F-7F-E8-C1-C5-AF-0B-02-62-C8-DF-99-A2-E8-94-78-3D-FF-76-16-16-B8-56-DB-21-67-F3-2D-41-14-6B-8E-76-A7

my client was receiving this:
EF-03-BC-06-B9-6A-6A-48-D2-F8-3D-2B-EA-99-A9-18-65-CF-30-77-D4-3D-F7-15-91-71-FD-52-65-BC-5E-7B-A7-4A-33-5E-58-2C-72-16-63-59-E4-99-61-A4-37-0E-75-5C-04-A0-72-65-D5-EC-EB-31-65-9D-01-95-5F-7F-E8-C1-C5-AF-0B-02-62-C8-DF-99-A2-E8-94-78-3D-FF-76-16-16-B8-56-DB-21-67-F3-2D-41-14-6B-8E-76-A7-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00