### PR TITLE
Fix building when mirror polling is used

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Ignorance/Ignorance.cs
+++ b/Assets/Mirror/Runtime/Transport/Ignorance/Ignorance.cs
@@ -618,7 +618,7 @@ namespace IgnoranceTransport
 
                 if (statusUpdateTimer >= clientStatusUpdateInterval)
                 {
-                    Client.Commands.Enqueue(new IgnoranceCommandPacket { Type = IgnoranceCommandType.ClientRequestsStatusUpdate });
+                    Client.Commands.Enqueue(new IgnoranceCommandPacket { Type = IgnoranceCommandType.ClientStatusRequest });
                     statusUpdateTimer = 0f;
                 }
             }


### PR DESCRIPTION
ClientRequestsStatusUpdate was renamed in a previous commit