### PR TITLE
Exposed local endpoint on IgnoranceClient. 

### DIFF
--- a/Assets/Mirror/Transports/Ignorance/Ignorance.cs
+++ b/Assets/Mirror/Transports/Ignorance/Ignorance.cs
@@ -9,6 +9,7 @@ using IgnoranceCore;
 using Mirror;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using UnityEngine;
 
 namespace IgnoranceTransport
@@ -320,6 +321,18 @@ namespace IgnoranceTransport
             };
 
             return builder.Uri;
+        }
+
+        public IPEndPoint GetLocalEndPoint()
+        {
+            if (Server != null)
+            {
+                return new IPEndPoint(IPAddress.Parse(Server.BindAddress), Server.BindPort);
+            }
+            else
+            {
+                return new IPEndPoint(IPAddress.Parse(Client.BindAddress), Client.BindPort);
+            }
         }
 
         public override void Shutdown()


### PR DESCRIPTION
Also added the ability to specify the local endpoint if desired.

This is useful for Noble Connect specifically, but also anyone else doing anything like port-forwarding, nat traversal, or relays.